### PR TITLE
Fix bases formula editor

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -281,6 +281,14 @@ export default class SpacekeysPlugin extends Plugin {
 				return true;
 		}
 
+		// check if we are in the bases formula editor
+		// Should be changed to something more robust... Obviously this is very
+		// dependent on the structure of the page which might change.
+		// Once Bases API is out it will be cleaner to check this
+		if (document.activeElement instanceof HTMLElement &&
+		document.activeElement.parentElement?.parentElement?.parentElement?.classList.contains("formula-editor"))
+			return true
+
 		// Activate
 		this.activateLeader();
 		return false;


### PR DESCRIPTION
Make sure you can still press space in the bases formula editor popup window. When in this window, mdview and isCodeMirror are considered `true`.

Closed other request because I realized it broke something else (caused normal mode vim not to trigger leader)

Still should just be a temporary fix until the API is out.

I'm not super familiar with webdev, so maybe there should be another error check somewhere...